### PR TITLE
Add configurable PICFLAG.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ LINKFLAGS_coverage = --coverage
 
 # General flags
 CPPFLAGS  ?=
-CFLAGS    += $(CFLAGS_$(variant)) -std=c99 -fPIC -DHAVE_FIRM_REVISION_H
+PICFLAG   ?= -fPIC
+CFLAGS    += $(CFLAGS_$(variant)) -std=c99 $(PICFLAG) -DHAVE_FIRM_REVISION_H
 CFLAGS    += -Wall -W -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wwrite-strings
 LINKFLAGS += $(LINKFLAGS_$(variant)) -lm
 VPATH = $(srcdir) $(gendir)


### PR DESCRIPTION
On some environments, correct PIC flag should be used.
Leave -fPIC as default.
See also gcc/config/picflag.m4 or so.
