### PR TITLE
Add OpenBSD support.

### DIFF
--- a/ir/be/begnuas.c
+++ b/ir/be/begnuas.c
@@ -30,7 +30,7 @@
 #include <assert.h>
 #include <ctype.h>
 
-/** by default, we generate assembler code for the Linux gas */
+/** by default, we generate assembler code for GNU as */
 elf_variant_t          be_gas_elf_variant   = ELF_VARIANT_NORMAL;
 bool                   be_gas_emit_types    = true;
 char                   be_gas_elf_type_char = '@';

--- a/ir/be/machine_triple.c
+++ b/ir/be/machine_triple.c
@@ -143,6 +143,8 @@ ir_machine_triple_t *ir_get_host_machine_triple(void)
 		"darwin";
 #elif defined(__FreeBSD__)
 		"freebsd";
+#elif defined(__OpenBSD__)
+		"openbsd";
 #elif defined(__gnu_linux__)
 		"linux-gnu";
 #elif defined(__linux__)

--- a/ir/be/platform.c
+++ b/ir/be/platform.c
@@ -167,7 +167,10 @@ void ir_platform_set(ir_machine_triple_t const *machine,
 		if (strstr(os, "gnu") != NULL)
 			ppdef1("__gnu_linux__");
 	} else if (strstart(os, "freebsd")) {
-		ppdef("__FreeBSD__", "");
+		ppdef1("__FreeBSD__");
+		goto BSD;
+	} else if (strstart(os, "openbsd")) {
+		ppdef1("__OpenBSD__");
 		goto BSD;
 	} else if (strstr(os, "bsd") != NULL) {
 BSD:

--- a/ir/stat/stat_timing.c
+++ b/ir/stat/stat_timing.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 
 #include <unistd.h>
 #include <time.h>


### PR DESCRIPTION
As the title says, recognize OpenBSD as a platform. libFirm and cparser work perfectly well on OpenBSD/amd64 and OpenBSD/i386, and there are packages of libFirm and cparser available in our package repository for both architectures.

While here, tweak a comment (there's no such thing as a Linux assembler but there is a GNU assembler, which is the assembler libFirm targets by default).