### PR TITLE
riscv32 backend: lowering of builtin va_arg and lowering of floating_…

### DIFF
--- a/ir/be/riscv/riscv_cconv.c
+++ b/ir/be/riscv/riscv_cconv.c
@@ -8,6 +8,7 @@
 #include "betranshlp.h"
 #include "gen_riscv_regalloc_if.h"
 #include "riscv_bearch_t.h"
+#include "bevarargs.h"
 #include "util.h"
 
 static unsigned const regs_param_gp[] = {
@@ -32,9 +33,12 @@ void riscv_determine_calling_convention(riscv_calling_convention_t *const cconv,
 	riscv_reg_or_slot_t *params   = NULL;
 	size_t               gp_param = 0;
 	size_t         const n_params = get_method_n_params(fun_type);
-	if (n_params != 0) {
+	
+    int offset = !is_method_variadic(fun_type) ? ARRAY_SIZE(regs_param_gp) : 0;
+    
+    if (n_params != 0) {
 		params = XMALLOCNZ(riscv_reg_or_slot_t, n_params);
-
+    
 		for (size_t i = 0; i != n_params; ++i) {
 			ir_type *const param_type = get_method_param_type(fun_type, i);
 			ir_mode *const param_mode = get_type_mode(param_type);
@@ -43,18 +47,21 @@ void riscv_determine_calling_convention(riscv_calling_convention_t *const cconv,
 			} else if (mode_is_float(param_mode)) {
 				panic("TODO");
 			} else {
-				if (param_type->flags & tf_lowered_dw && gp_param % 2 != 0)
-					++gp_param;
-				if (gp_param < ARRAY_SIZE(regs_param_gp))
-					params[i].reg = &riscv_registers[regs_param_gp[gp_param]];
-				params[i].offset = (gp_param - ARRAY_SIZE(regs_param_gp)) * (RISCV_MACHINE_SIZE / 8);
-				++gp_param;
+				
+			
+           		if (gp_param < ARRAY_SIZE(regs_param_gp)) {                    
+                    params[i].reg = &riscv_registers[regs_param_gp[gp_param]];
+                }       
+                params[i].offset = (gp_param - offset) * (RISCV_MACHINE_SIZE / 8);
+				++gp_param;	
 			}
 		}
 	}
+    
 	cconv->param_stack_size = gp_param * (RISCV_MACHINE_SIZE / 8);
-	cconv->n_mem_param      = gp_param > ARRAY_SIZE(regs_param_gp) ? gp_param - ARRAY_SIZE(regs_param_gp) : 0;
-	cconv->parameters       = params;
+	cconv->n_mem_param      = gp_param > ARRAY_SIZE(regs_param_gp) ? gp_param - offset : 0;
+	cconv->parameters       = params;     
+	
 
 	/* Handle results. */
 	riscv_reg_or_slot_t *results   = NULL;
@@ -93,15 +100,22 @@ void riscv_layout_parameter_entities(riscv_calling_convention_t *const cconv, ir
 		if (!is_atomic_type(param_type))
 			panic("unhandled parameter type");
 		ir_entity *param_ent = param_map[i];
-		if (!param->reg) {
-			if (!param_ent)
+		if (!param->reg || is_method_variadic(fun_type)) {              
+			if (!param_ent){                
 				param_ent = new_parameter_entity(frame_type, i, param_type);
+            }
 			assert(get_entity_offset(param_ent) == INVALID_OFFSET);
 			set_entity_offset(param_ent, param->offset);
 		}
 		param->entity = param_ent;
-	}
+	} 
 	free(param_map);
+  
+
+	if (is_method_variadic(fun_type)) {
+		int const offset = (cconv->n_parameters)*(RISCV_MACHINE_SIZE / 8);
+		cconv->va_start_addr = be_make_va_start_entity(frame_type, offset);
+	} 
 }
 
 void riscv_free_calling_convention(riscv_calling_convention_t *const cconv)

--- a/ir/be/riscv/riscv_cconv.h
+++ b/ir/be/riscv/riscv_cconv.h
@@ -17,8 +17,10 @@ typedef struct riscv_reg_or_slot_t {
 typedef struct riscv_calling_convention_t {
 	unsigned             param_stack_size;
 	unsigned             n_mem_param;
+	unsigned             n_parameters; 
 	riscv_reg_or_slot_t *parameters;
 	riscv_reg_or_slot_t *results;
+    ir_entity          *va_start_addr; 
 } riscv_calling_convention_t;
 
 void riscv_determine_calling_convention(riscv_calling_convention_t *cconv, ir_type *fun_type);

--- a/ir/be/riscv/riscv_lower64.c
+++ b/ir/be/riscv/riscv_lower64.c
@@ -3,9 +3,72 @@
  * Copyright (C) 2018 Christoph Mallon.
  */
 #include "riscv_lower64.h"
-
+#include "gen_riscv_new_nodes.h" 
 #include "gen_riscv_regalloc_if.h"
+#include "ircons_t.h"
 #include "lower_dw.h"
+
+static void lower64_minus(ir_node *const node)
+{
+	dbg_info *dbgi         = get_irn_dbg_info(node);
+	ir_graph *irg          = get_irn_irg(node);
+	ir_node  *block        = get_nodes_block(node);
+	ir_node  *op           = get_Minus_op(node);
+	ir_node  *right_low    = get_lowered_low(op);
+	ir_node  *right_high   = get_lowered_high(op);
+	
+    ir_mode  *munsigned = get_irn_mode(right_low);
+	ir_node  *cnull     = new_r_Const_null(irg, munsigned);
+	ir_node  *inv_low   = new_rd_Eor(dbgi, block, cnull, right_low);        
+	ir_node  *inv_high  = new_rd_Eor(dbgi, block, cnull, right_high);
+    ir_node  *one       = new_r_Const_long(irg, munsigned, 1);
+    ir_node  *res_low   = new_rd_Add(dbgi, block, inv_low, one); 
+    ir_node  *sltu      = new_bd_riscv_sltu_t(dbgi, block, res_low, inv_low, munsigned);
+    ir_node  *res_high  = new_rd_Add(dbgi, block, inv_high, sltu);
+    
+	ir_set_dw_lowered(node, res_low, res_high);
+} 
+
+static void lower64_add(ir_node *const node)
+{
+	dbg_info *dbgi       = get_irn_dbg_info(node);
+	ir_node  *block      = get_nodes_block(node);
+	ir_node  *left       = get_Add_left(node);
+	ir_node  *right      = get_Add_right(node);
+	ir_node  *left_low   = get_lowered_low(left);
+	ir_node  *left_high  = get_lowered_high(left)
+    ;
+	ir_node  *right_low  = get_lowered_low(right);
+	ir_node  *right_high = get_lowered_high(right);
+	
+	ir_node  *addl       = new_rd_Add(dbgi, block, left_low, right_low);   
+    ir_node  *addh       = new_rd_Add(dbgi, block, left_high, right_high);
+	ir_mode  *mode       = get_node_high_mode(node); 
+    ir_node  *sltu      =  new_bd_riscv_sltu_t(dbgi, block, addl, left_low, mode);
+    ir_node  *addh2       = new_rd_Add(dbgi, block, addh, sltu);
+	ir_set_dw_lowered(node, addl, addh2); 
+} 
+
+static void lower64_sub(ir_node *const node)
+{
+	dbg_info *dbgi       = get_irn_dbg_info(node);
+	ir_node  *block      = get_nodes_block(node);
+	ir_node  *left       = get_Sub_left(node);
+	ir_node  *right      = get_Sub_right(node);
+	ir_node  *left_low   = get_lowered_low(left);
+	ir_node  *left_high  = get_lowered_high(left)
+    ;
+	ir_node  *right_low  = get_lowered_low(right);
+	ir_node  *right_high = get_lowered_high(right);
+    
+	ir_node  *subl       = new_rd_Sub(dbgi, block, left_low, right_low);
+	ir_node  *subh       = new_rd_Sub(dbgi, block, left_high, right_high);
+    ir_mode  *mode       = get_node_high_mode(node); 
+    ir_node  *sltu      =  new_bd_riscv_sltu_t(dbgi, block, left_low, subl, mode);
+    ir_node  *subh2       = new_rd_Sub(dbgi, block, subh, sltu);
+	ir_set_dw_lowered(node, subl, subh2); 
+} 
+
 
 void riscv_lower64(void)
 {
@@ -18,5 +81,8 @@ void riscv_lower64(void)
 	};
 
 	ir_prepare_dw_lowering(&lower_dw_params);
+    ir_register_dw_lower_function(op_Add, lower64_add); 
+    ir_register_dw_lower_function(op_Sub, lower64_sub); 
+    ir_register_dw_lower_function(op_Minus, lower64_minus); 
 	ir_lower_dw_ops();
 }

--- a/ir/be/riscv/riscv_new_nodes.c
+++ b/ir/be/riscv/riscv_new_nodes.c
@@ -54,6 +54,15 @@ int riscv_switch_attrs_equal(ir_node const *const a, ir_node const *const b)
 		riscv_attrs_equal_(&a_attr->attr, &b_attr->attr) &&
 		be_switch_attrs_equal(&a_attr->swtch, &b_attr->swtch);
 }
+int riscv_farith_attrs_equal(ir_node const *const a, ir_node const *const b)
+{
+	riscv_farith_attr_t const *const a_attr = get_riscv_farith_attr_const(a);
+	riscv_farith_attr_t const *const b_attr = get_riscv_farith_attr_const(b);
+	return
+		riscv_attrs_equal_(&a_attr->attr, &b_attr->attr) &&
+		a_attr->mode == b_attr->mode;
+}
+ 
 
 static void dump_immediate(FILE *const F, char const *const prefix, ir_node const *const n)
 {
@@ -62,7 +71,8 @@ static void dump_immediate(FILE *const F, char const *const prefix, ir_node cons
 		fputc(' ', F);
 		if (prefix)
 			fprintf(F, "%s(", prefix);
-		fputs(get_entity_name(imm->ent), F);
+		const char *name = get_entity_name(imm->ent);
+		if(name) fputs(name, F);
 		if (imm->val != 0)
 			fprintf(F, "%+" PRId32, imm->val);
 		if (prefix)
@@ -145,6 +155,7 @@ void riscv_dump_node(FILE *const F, ir_node const *const n, dump_reason_t const 
 			case iro_riscv_sub:
 			case iro_riscv_switch:
 			case iro_riscv_xor:
+			case iro_riscv_sltu_t:
 				break;
 			}
 			break;

--- a/ir/be/riscv/riscv_new_nodes_t.h
+++ b/ir/be/riscv/riscv_new_nodes_t.h
@@ -21,5 +21,6 @@ int riscv_attrs_equal(ir_node const *a, ir_node const *b);
 int riscv_immediate_attrs_equal(ir_node const *a, ir_node const *b);
 int riscv_cond_attrs_equal(ir_node const *a, ir_node const *b);
 int riscv_switch_attrs_equal(ir_node const *a, ir_node const *b);
+int riscv_farith_attrs_equal(ir_node const *a, ir_node const *b);
 
 #endif

--- a/ir/be/riscv/riscv_nodes_attr.h
+++ b/ir/be/riscv/riscv_nodes_attr.h
@@ -51,6 +51,13 @@ typedef struct riscv_switch_attr_t {
 	be_switch_attr_t swtch;
 } riscv_switch_attr_t;
 
+/** attributes for floatingpoint arithmetic operations */
+typedef struct riscv_farith_attr_t {
+	riscv_attr_t  attr;
+	ir_mode    *mode; /* operation mode */
+} riscv_farith_attr_t;
+ 
+
 static inline riscv_attr_t const *get_riscv_attr_const(ir_node const *const node)
 {
 	return (riscv_attr_t const*)get_irn_generic_attr_const(node);
@@ -74,6 +81,11 @@ static inline riscv_immediate_attr_t const *get_riscv_immediate_attr_const(ir_no
 static inline riscv_switch_attr_t const *get_riscv_switch_attr_const(ir_node const *const node)
 {
 	return (riscv_switch_attr_t const*)get_irn_generic_attr_const(node);
+}
+
+static inline riscv_farith_attr_t const *get_riscv_farith_attr_const(ir_node const *const node)
+{
+	return (riscv_farith_attr_t const*)get_irn_generic_attr_const(node);
 }
 
 char const *riscv_get_cond_name(riscv_cond_t cond);

--- a/ir/be/riscv/riscv_spec.pl
+++ b/ir/be/riscv/riscv_spec.pl
@@ -116,6 +116,14 @@ and => { template => $binOp },
 
 andi => { template => $immediateOp },
 
+
+sltu_t => {
+	ins       => [ "left", "right" ],
+	attr_type => "",
+	dump_func => "NULL",
+}, 
+ 
+
 bcc => {
 	state     => "pinned",
 	op_flags  => [ "cfopcode", "forking" ],


### PR DESCRIPTION
Hi libfirm-team,
the riscv32-backend does currently not support variadic arguments. The pull-request makes some
changes to add support for it. 
A larger example using variadic functions built on these changes is available here:
https://github.com/michg/cparserlibfirm_riscv32.
Best regards,
Michael 