### PR TITLE
Fix compilation on AArch64.

### DIFF
--- a/ir/be/machine_triple.c
+++ b/ir/be/machine_triple.c
@@ -127,6 +127,8 @@ ir_machine_triple_t *ir_get_host_machine_triple(void)
 		"sparc";
 #elif defined(__arm__)
 		"arm";
+#elif defined(__aarch64__)
+		"aarch64";
 #else
 		"unknown";
 #endif

--- a/ir/tv/fltcalc.c
+++ b/ir/tv/fltcalc.c
@@ -1074,6 +1074,9 @@ void init_fltcalc(unsigned precision)
 #elif LDBL_MANT_DIG == 53
 	assert(sizeof(long double) == 8);
 	long_double_desc = (float_descriptor_t) { 11, 52, 0 };
+#elif LDBL_MANT_DIG == 113
+	assert(sizeof(long double) == 16);
+	long_double_desc = (float_descriptor_t) { 15, 112, 0 };
 #else
 #error "Unsupported long double format"
 #endif


### PR DESCRIPTION
Extend tarval float module to recognize quad precision floats that are used on AArch64 as a long double type. This allows cparser/libfirm to be compiled under AArch64.

Also recognize AArch64 as host cpu type during machine triple creation.