### PR TITLE
Change IRC channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Mailing list: https://lists.ira.uni-karlsruhe.de/mailman/listinfo/firm
 
 Bugtracker: http://pp.ipd.kit.edu/~firm/bugs
 
-Internet relay chat: irc://chat.freenode.net/#firm
+Internet relay chat: `#firm` on `irc.libera.chat` 


### PR DESCRIPTION
The current #firm channel on freenode looks empty or even disowned. A parallel unofficial channel has been set up on [Libera.Chat](https://libera.chat/), please consider also updating the IRC channel on the website.