### PR TITLE
Switch to Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Building and Installation
 
 Prerequisites for the build:
 
-* Python (2.7.x or >=3.3 are supported)
+* Python (>=3.3 are supported)
 * Perl
 * an ANSI C99 compiler (gcc, clang, icc are known to work)
 * Git

--- a/scripts/gen_ir.py
+++ b/scripts/gen_ir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file is part of libFirm.
 # Copyright (C) 2012 Karlsruhe Institute of Technology.

--- a/support/statev_sql.py
+++ b/support/statev_sql.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # This file is part of libFirm.
 # Copyright (C) 2012 Karlsruhe Institute of Technology.


### PR DESCRIPTION
Python 2 is deprecated and most distros don't ship it anymore. Let's use Python 3 instead.