### PR TITLE
Python 3.12 no longer support backslash character string for regex

### DIFF
--- a/scripts/filters.py
+++ b/scripts/filters.py
@@ -6,7 +6,7 @@ import re
 
 
 def filtjoin(string, joinstring):
-    args = re.split('\s*\n\s*', string)
+    args = re.split(r"\s*\n\s*", string)
     if args[0] == '':
         args = args[1:]
     if len(args) > 0 and args[-1] == '':

--- a/scripts/irops.py
+++ b/scripts/irops.py
@@ -1,7 +1,6 @@
 from jinjautil import export_filter, export
 #from jinja2._compat import string_types use str instead
 from filters import arguments
-import imp
 import sys
 
 


### PR DESCRIPTION
Python 3.12 produces **SyntaxWarning** for backslash character string and in future this will turn into **SyntaxError**. 
Minimal change made to one file **scripts/filters.py**.

[link to Python 3.12 change notes](https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes)
