### PR TITLE
gen_ir: Remove an unused import of the imp module

### DIFF
--- a/scripts/irops.py
+++ b/scripts/irops.py
@@ -1,7 +1,6 @@
 from jinjautil import export_filter, export
 #from jinja2._compat import string_types use str instead
 from filters import arguments
-import imp
 import sys
 
 


### PR DESCRIPTION
Building libfirm on Fedora 41 which includes Python 3.13 fails because the imp module was removed in Python 3.12.  Simply removing the import is enough to make the build succeed.