### PR TITLE
Imcompatiable pointer type in unittests/dep.c, fixed to compile tests

### DIFF
--- a/unittests/deq.c
+++ b/unittests/deq.c
@@ -171,7 +171,7 @@ static void test_mixed(void)
 }
 
 typedef void (*push_func)(deq_t *deq, unsigned n, char *refp);
-typedef void (*pop_func)(deq_t *deq, unsigned n, char *refp);
+typedef void (*pop_func)(deq_t *deq, unsigned n, const char *refp);
 static void test_mixed_4(push_func push0, pop_func pop0,
                          push_func push1, pop_func pop1)
 {


### PR DESCRIPTION
Just modified the pop_func in dep.c from
```c
typedef void (*pop_func)(deq_t *deq, unsigned n, char *refp);
```
to 
```c
typedef void (*pop_func)(deq_t *deq, unsigned n, const char *refp);
```
and it compiles successfully.