### PR TITLE
x64 calling convention: fix parameter passing definitions.

### DIFF
--- a/ir/be/amd64/amd64_cconv.c
+++ b/ir/be/amd64/amd64_cconv.c
@@ -275,7 +275,7 @@ void amd64_cconv_init(void)
 	if (amd64_use_x64_abi)
 		be_cconv_add_regs(default_callee_saves, x64_callee_saves, ARRAY_SIZE(x64_callee_saves));
 
-	static const arch_register_t* const param_regs_list[] = {
+	static const arch_register_t* const param_regs_list_amd64[] = {
 		&amd64_registers[REG_RDI],
 		&amd64_registers[REG_RSI],
 		&amd64_registers[REG_RDX],
@@ -283,8 +283,15 @@ void amd64_cconv_init(void)
 		&amd64_registers[REG_R8],
 		&amd64_registers[REG_R9],
 	};
-	param_regs   = amd64_use_x64_abi ? &param_regs_list[2] : param_regs_list;
-	n_param_regs = ARRAY_SIZE(param_regs_list) - (amd64_use_x64_abi ? 2 : 0);
+
+	static const arch_register_t* const param_regs_list_x64[] = {
+		&amd64_registers[REG_RCX],
+		&amd64_registers[REG_RDX],
+		&amd64_registers[REG_R8],
+		&amd64_registers[REG_R9],
+	};
+	param_regs   = amd64_use_x64_abi ? param_regs_list_x64 : param_regs_list_amd64;
+	n_param_regs = amd64_use_x64_abi ? 4 : 6;
 
 	n_float_param_regs = amd64_use_x64_abi ? 4 : ARRAY_SIZE(float_param_regs);
 }

--- a/ir/be/amd64/amd64_transform.c
+++ b/ir/be/amd64/amd64_transform.c
@@ -2484,15 +2484,29 @@ static ir_node *conv_x87_to_sse(dbg_info *dbgi, ir_node *block, ir_node *op,
 
 static ir_node *conv_int_to_x87(dbg_info *dbgi, ir_node *block, ir_node *val)
 {
-	ir_mode        *const mode    = get_irn_mode(val);
-	ir_node        *const new_val = extend_if_necessary(dbgi, block, val);
-	x86_insn_size_t const size    = get_size_32_64_from_mode(mode);
-	if (!mode_is_signed(mode))
-		panic("unsigned int -> x87 NIY");
+	ir_mode        *mode = get_irn_mode(val);
+	x86_insn_size_t size = get_size_32_64_from_mode(mode);
 
 	ir_node *in[5];
 	int      n_in = 0;
 	x86_addr_t addr;
+	ir_node *  new_val;
+
+	if (mode_is_signed(mode)) {
+		new_val = extend_if_necessary(dbgi, block, val);
+
+	} else if (size == X86_SIZE_32) {
+		new_val = gen_extend(dbgi, block, val, mode);
+		mode    = get_irn_mode(new_val);
+		size    = X86_SIZE_64;
+
+	} else if ((size == X86_SIZE_64) && !mode_is_signed(mode)) {
+		panic("unsigned long long -> x87 NIY");
+
+	} else {
+		new_val = extend_if_necessary(dbgi, block, val);
+	}
+
 	store_to_temp(new_bd_amd64_mov_store, reg_reg_mem_reqs, &addr, dbgi, block,
 	              in, &n_in, new_val, size);
 	assert(n_in < (int)ARRAY_SIZE(in));


### PR DESCRIPTION
The canonical amd64 parameter registers are rdi,rsi,rdx,rcx,r8, and r9; whereas the x64 parameter register are rcx,rdx,r8, and r9, so almost like the last four amd64 registers, but not quite:-)